### PR TITLE
Fix: Prevent 'Add' button from disappearing on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,9 +89,9 @@
                         <!-- Custom Add -->
                         <div class="mb-6">
                             <p class="text-lg font-semibold text-gray-700 mb-3">Custom Amount</p>
-                            <div class="flex gap-3">
-                                <input type="number" id="custom-amount" placeholder="Enter amount in ml" class="flex-1 p-4 border-2 border-gray-200 rounded-xl focus:outline-none focus:border-blue-500 transition">
-                                <button id="add-custom" class="bg-green-500 hover:bg-green-600 text-white font-bold py-4 px-6 rounded-xl transition-all duration-300 transform hover:scale-105">
+                            <div class="flex flex-col sm:flex-row gap-3">
+                                <input type="number" id="custom-amount" placeholder="Enter amount in ml" class="flex-1 p-4 border-2 border-gray-200 rounded-xl focus:outline-none focus:border-blue-500 transition w-full">
+                                <button id="add-custom" class="bg-green-500 hover:bg-green-600 text-white font-bold py-4 px-6 rounded-xl transition-all duration-300 transform hover:scale-105 w-full sm:w-auto">
                                     <i class="fas fa-plus mr-2"></i>Add
                                 </button>
                             </div>


### PR DESCRIPTION
The 'Add' button in the 'Custom Amount' section was disappearing on mobile view because the flex container did not have enough space.

This change makes the container a flex column on mobile screens and a flex row on larger screens, ensuring the button is always visible. The button is now placed below the input field on mobile.