### PR TITLE
Fix duplicate key error in TodaysEntriesCard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,11 @@ function App() {
 
   const addWaterEntry = (amount: number) => {
     const todayStr = new Date().toISOString().split('T')[0];
-    const newEntry: Entry = { amount, timestamp: Date.now() };
+    const newEntry: Entry = {
+      id: `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      amount,
+      timestamp: Date.now()
+    };
 
     setLogs(prevLogs => {
       const todayLogIndex = prevLogs.findIndex(log => log.date === todayStr);
@@ -59,13 +63,13 @@ function App() {
     });
   };
 
-  const deleteEntry = (timestamp: number) => {
+  const deleteEntry = (id: string) => {
     const todayStr = new Date().toISOString().split('T')[0];
     setLogs(prevLogs => {
       const newLogs = [...prevLogs];
       const todayLogIndex = newLogs.findIndex(log => log.date === todayStr);
       if (todayLogIndex > -1) {
-        newLogs[todayLogIndex].entries = newLogs[todayLogIndex].entries.filter(entry => entry.timestamp !== timestamp);
+        newLogs[todayLogIndex].entries = newLogs[todayLogIndex].entries.filter(entry => entry.id !== id);
         if (newLogs[todayLogIndex].entries.length === 0) {
           return newLogs.filter(log => log.date !== todayStr);
         }
@@ -74,13 +78,13 @@ function App() {
     });
   };
 
-  const updateEntry = (timestamp: number, newAmount: number) => {
+  const updateEntry = (id: string, newAmount: number) => {
     const todayStr = new Date().toISOString().split('T')[0];
     setLogs(prevLogs => {
       const newLogs = [...prevLogs];
       const todayLogIndex = newLogs.findIndex(log => log.date === todayStr);
       if (todayLogIndex > -1) {
-        const entryIndex = newLogs[todayLogIndex].entries.findIndex(entry => entry.timestamp === timestamp);
+        const entryIndex = newLogs[todayLogIndex].entries.findIndex(entry => entry.id === id);
         if (entryIndex > -1) {
           newLogs[todayLogIndex].entries[entryIndex].amount = newAmount;
         }

--- a/src/components/DailyIntakeCard.tsx
+++ b/src/components/DailyIntakeCard.tsx
@@ -1,15 +1,13 @@
 import React, { useState } from 'react';
-import type { Log } from '../types';
 
 interface DailyIntakeCardProps {
-  todayLog: Log | undefined;
   dailyGoal: number;
   setDailyGoal: (goal: number) => void;
   addWaterEntry: (amount: number) => void;
   dailyTotal: number;
 }
 
-const DailyIntakeCard: React.FC<DailyIntakeCardProps> = ({ todayLog, dailyGoal, setDailyGoal, addWaterEntry, dailyTotal }) => {
+const DailyIntakeCard: React.FC<DailyIntakeCardProps> = ({ dailyGoal, setDailyGoal, addWaterEntry, dailyTotal }) => {
   const [customAmount, setCustomAmount] = useState('');
 
   const percentage = dailyGoal > 0 ? Math.min((dailyTotal / dailyGoal) * 100, 100) : 0;

--- a/src/components/DailyTracker.tsx
+++ b/src/components/DailyTracker.tsx
@@ -8,8 +8,8 @@ interface DailyTrackerProps {
   dailyGoal: number;
   setDailyGoal: (goal: number) => void;
   addWaterEntry: (amount: number) => void;
-  deleteEntry: (timestamp: number) => void;
-  updateEntry: (timestamp: number, newAmount: number) => void;
+  deleteEntry: (id: string) => void;
+  updateEntry: (id: string, newAmount: number) => void;
   dailyTotal: number;
 }
 
@@ -20,7 +20,6 @@ const DailyTracker: React.FC<DailyTrackerProps> = ({ logs, dailyGoal, setDailyGo
   return (
     <div className="space-y-8">
       <DailyIntakeCard
-        todayLog={todayLog}
         dailyGoal={dailyGoal}
         setDailyGoal={setDailyGoal}
         addWaterEntry={addWaterEntry}

--- a/src/components/TodaysEntriesCard.tsx
+++ b/src/components/TodaysEntriesCard.tsx
@@ -3,30 +3,30 @@ import type { Log, Entry } from '../types';
 
 interface TodaysEntriesCardProps {
   todayLog: Log | undefined;
-  deleteEntry: (timestamp: number) => void;
-  updateEntry: (timestamp: number, newAmount: number) => void;
+  deleteEntry: (id: string) => void;
+  updateEntry: (id: string, newAmount: number) => void;
 }
 
 const TodaysEntriesCard: React.FC<TodaysEntriesCardProps> = ({ todayLog, deleteEntry, updateEntry }) => {
-  const [editingTimestamp, setEditingTimestamp] = useState<number | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
   const [editingAmount, setEditingAmount] = useState<string>('');
 
   const handleEdit = (entry: Entry) => {
-    setEditingTimestamp(entry.timestamp);
+    setEditingId(entry.id);
     setEditingAmount(entry.amount.toString());
   };
 
   const handleCancel = () => {
-    setEditingTimestamp(null);
+    setEditingId(null);
     setEditingAmount('');
   };
 
-  const handleSave = (timestamp: number) => {
+  const handleSave = (id: string) => {
     const newAmount = parseInt(editingAmount);
     if (newAmount > 0) {
-      updateEntry(timestamp, newAmount);
+      updateEntry(id, newAmount);
     }
-    setEditingTimestamp(null);
+    setEditingId(null);
     setEditingAmount('');
   };
 
@@ -44,8 +44,8 @@ const TodaysEntriesCard: React.FC<TodaysEntriesCardProps> = ({ todayLog, deleteE
             </div>
           ) : (
             sortedEntries.map(entry => (
-              <div key={entry.timestamp} className="entry-item bg-blue-50 p-4 rounded-xl flex items-center justify-between">
-                {editingTimestamp === entry.timestamp ? (
+              <div key={entry.id} className="entry-item bg-blue-50 p-4 rounded-xl flex items-center justify-between">
+                {editingId === entry.id ? (
                   <>
                     <div className="flex items-center flex-grow">
                       <input
@@ -56,7 +56,7 @@ const TodaysEntriesCard: React.FC<TodaysEntriesCardProps> = ({ todayLog, deleteE
                       />
                     </div>
                     <div className="flex">
-                      <button onClick={() => handleSave(entry.timestamp)} className="text-green-500 hover:text-green-700 mr-2">
+                      <button onClick={() => handleSave(entry.id)} className="text-green-500 hover:text-green-700 mr-2">
                         <i className="fas fa-check"></i>
                       </button>
                       <button onClick={handleCancel} className="text-red-500 hover:text-red-700">
@@ -79,7 +79,7 @@ const TodaysEntriesCard: React.FC<TodaysEntriesCardProps> = ({ todayLog, deleteE
                       <button onClick={() => handleEdit(entry)} className="edit-entry text-blue-500 hover:text-blue-700 mr-2">
                         <i className="fas fa-pencil-alt"></i>
                       </button>
-                      <button onClick={() => deleteEntry(entry.timestamp)} className="delete-entry text-red-500 hover:text-red-700">
+                      <button onClick={() => deleteEntry(entry.id)} className="delete-entry text-red-500 hover:text-red-700">
                         <i className="fas fa-trash"></i>
                       </button>
                     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export interface Entry {
+  id: string;
   amount: number;
   timestamp: number;
 }
@@ -15,6 +16,6 @@ export interface Achievement {
   icon: string;
   trigger: {
     type: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
 }

--- a/src/utils/achievementChecker.ts
+++ b/src/utils/achievementChecker.ts
@@ -224,14 +224,16 @@ export function checkAchievements(logs: Log[], dailyGoal: number, unlockedAchiev
             case 'consecutive_goals':
                 earned = checkConsecutiveGoals(dailyTotals, dailyGoal, trigger.days);
                 break;
-            case 'total_volume':
+            case 'total_volume': {
                 const totalVolume = logs.reduce((sum, log) => sum + log.entries.reduce((s, e) => s + e.amount, 0), 0);
                 earned = totalVolume >= trigger.amount;
                 break;
-            case 'goal_met':
+            }
+            case 'goal_met': {
                 const goalsMetCount = [...dailyTotals.values()].filter(total => total >= dailyGoal).length;
                 earned = goalsMetCount >= trigger.times;
                 break;
+            }
             case 'goals_in_week':
                 earned = checkGoalsInWeek(dailyTotals, dailyGoal, trigger.count);
                 break;


### PR DESCRIPTION
- Replaced timestamp with a unique ID for keys in the entry list.
- This resolves the 'Encountered two children with the same key' error.
- Also fixed linting errors.