### PR TITLE
feat: Make achievement modal background semi-transparent

### DIFF
--- a/src/components/AchievementModal.tsx
+++ b/src/components/AchievementModal.tsx
@@ -11,7 +11,7 @@ const AchievementModal: React.FC<AchievementModalProps> = ({ isOpen, achievement
   if (!isOpen || !achievement) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 bg-[rgba(0,0,0,0.5)] z-50 flex items-center justify-center p-4">
       <div className="achievement-modal-content bg-gradient-to-br from-blue-100 to-cyan-100 rounded-2xl shadow-2xl p-6 max-w-sm w-full mx-auto text-center relative">
         <button onClick={onClose} className="absolute top-3 right-3 text-gray-500 hover:text-gray-800">
           <i className="fas fa-times text-2xl"></i>


### PR DESCRIPTION
The achievement modal had a solid black background, which completely obscured the underlying application content.

This commit changes the background to be semi-transparent, providing a better user experience by allowing the application to remain partially visible. This is achieved by using a Tailwind CSS arbitrary value to set a background color with an alpha channel.