### PR TITLE
refactor(achievements): Update achievement card background colors

### DIFF
--- a/src/components/Achievements.tsx
+++ b/src/components/Achievements.tsx
@@ -23,8 +23,8 @@ const Achievements: React.FC<AchievementsProps> = ({ unlockedAchievements, allAc
           {sortedAchievements.map(achievement => {
             const isUnlocked = unlockedAchievements.includes(achievement.id);
             const badgeClasses = isUnlocked
-              ? 'bg-white bg-opacity-20'
-              : 'bg-black bg-opacity-20 filter grayscale cursor-help';
+              ? 'bg-yellow-400 bg-opacity-30'
+              : 'bg-blue-900 bg-opacity-40 filter grayscale cursor-help';
             const iconClass = isUnlocked ? 'text-amber-300' : 'text-gray-500';
             const textClass = isUnlocked ? 'text-white' : 'text-gray-300';
             const description = isUnlocked ? achievement.description : 'Locked';


### PR DESCRIPTION
The previous black background for locked achievement cards provided poor contrast with the text, making it difficult to read.

This commit refactors the background colors for both locked and unlocked achievement cards to be more visually appealing and improve readability.

- Locked cards now use a semi-transparent dark blue background.
- Unlocked cards now use a semi-transparent golden background to give them a more celebratory feel.