### PR TITLE
feat: Implement achievement modal on click

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,10 +17,11 @@ function App() {
   const [logs, setLogs] = useState<Log[]>([]);
   const [dailyGoal, setDailyGoal] = useState<number>(2000);
   const [unlockedAchievements, setUnlockedAchievements] = useState<string[]>([]);
-  const [newlyUnlocked, setNewlyUnlocked] = useState<Achievement | null>(null);
+  const [selectedAchievement, setSelectedAchievement] = useState<Achievement | null>(null);
   const [isAchievementModalOpen, setIsAchievementModalOpen] = useState(false);
   const [isCriticalModalOpen, setIsCriticalModalOpen] = useState(false);
   const [intakeWarningMessage, setIntakeWarningMessage] = useState('');
+  const [isSelectedAchievementUnlocked, setIsSelectedAchievementUnlocked] = useState(false);
 
   useEffect(() => {
     const savedLogs = JSON.parse(localStorage.getItem('waterTrackerData') || '[]') as Log[];
@@ -153,6 +154,12 @@ function App() {
     reader.readAsText(file);
   }
 
+  const handleAchievementClick = (achievement: Achievement, isUnlocked: boolean) => {
+    setSelectedAchievement(achievement);
+    setIsSelectedAchievementUnlocked(isUnlocked);
+    setIsAchievementModalOpen(true);
+  };
+
   const todayStr = new Date().toISOString().split('T')[0];
   const todayLog = logs.find(log => log.date === todayStr);
   const dailyTotal = todayLog ? todayLog.entries.reduce((sum, entry) => sum + entry.amount, 0) : 0;
@@ -171,8 +178,7 @@ function App() {
     const newlyUnlockedAchievements = checkAchievements(logs, dailyGoal, unlockedAchievements, allAchievements);
     if (newlyUnlockedAchievements.length > 0) {
       setUnlockedAchievements(prev => [...prev, ...newlyUnlockedAchievements.map(a => a.id)]);
-      setNewlyUnlocked(newlyUnlockedAchievements[0]);
-      setIsAchievementModalOpen(true);
+      handleAchievementClick(newlyUnlockedAchievements[0], true);
     }
   }, [logs, dailyGoal, unlockedAchievements]);
 
@@ -196,6 +202,7 @@ function App() {
             dailyGoal={dailyGoal}
             unlockedAchievements={unlockedAchievements}
             allAchievements={allAchievements}
+            onAchievementClick={handleAchievementClick}
             exportData={exportData}
             importData={importData}
           />
@@ -204,8 +211,9 @@ function App() {
       </div>
       <AchievementModal
         isOpen={isAchievementModalOpen}
-        achievement={newlyUnlocked}
+        achievement={selectedAchievement}
         onClose={() => setIsAchievementModalOpen(false)}
+        isUnlocked={isSelectedAchievementUnlocked}
       />
       <CriticalWarningModal
         isOpen={isCriticalModalOpen}

--- a/src/components/AchievementModal.tsx
+++ b/src/components/AchievementModal.tsx
@@ -5,10 +5,18 @@ interface AchievementModalProps {
   isOpen: boolean;
   achievement: Achievement | null;
   onClose: () => void;
+  isUnlocked: boolean;
 }
 
-const AchievementModal: React.FC<AchievementModalProps> = ({ isOpen, achievement, onClose }) => {
+const AchievementModal: React.FC<AchievementModalProps> = ({ isOpen, achievement, onClose, isUnlocked }) => {
   if (!isOpen || !achievement) return null;
+
+  const iconContainerClasses = isUnlocked
+    ? 'bg-blue-500'
+    : 'bg-gray-300';
+  const iconClasses = isUnlocked
+    ? 'text-white'
+    : 'text-gray-500';
 
   return (
     <div className="fixed inset-0 bg-[rgba(0,0,0,0.5)] z-50 flex items-center justify-center p-4">
@@ -16,11 +24,15 @@ const AchievementModal: React.FC<AchievementModalProps> = ({ isOpen, achievement
         <button onClick={onClose} className="absolute top-3 right-3 text-gray-500 hover:text-gray-800">
           <i className="fas fa-times text-2xl"></i>
         </button>
-        <div className="w-20 h-20 rounded-full bg-blue-500 flex items-center justify-center mx-auto mb-4 border-4 border-white shadow-lg">
-          <i className={`${achievement.icon} text-white text-4xl`}></i>
+        <div className={`w-20 h-20 rounded-full flex items-center justify-center mx-auto mb-4 border-4 border-white shadow-lg ${iconContainerClasses}`}>
+          <i className={`${achievement.icon} text-4xl ${iconClasses}`}></i>
         </div>
-        <h3 className="text-2xl font-bold text-gray-800 mb-2">Achievement Unlocked!</h3>
-        <p className="text-gray-600">{achievement.description}</p>
+        <h3 className="text-2xl font-bold text-gray-800 mb-2">{achievement.name}</h3>
+        {isUnlocked ? (
+          <p className="text-gray-600">{achievement.description}</p>
+        ) : (
+          <p className="text-gray-600">This achievement is still locked. Keep tracking your intake to unlock it!</p>
+        )}
       </div>
     </div>
   );

--- a/src/components/Achievements.tsx
+++ b/src/components/Achievements.tsx
@@ -4,9 +4,10 @@ import type { Achievement } from '../types';
 interface AchievementsProps {
   unlockedAchievements: string[];
   allAchievements: Achievement[];
+  onAchievementClick: (achievement: Achievement, isUnlocked: boolean) => void;
 }
 
-const Achievements: React.FC<AchievementsProps> = ({ unlockedAchievements, allAchievements }) => {
+const Achievements: React.FC<AchievementsProps> = ({ unlockedAchievements, allAchievements, onAchievementClick }) => {
   const sortedAchievements = [...allAchievements].sort((a, b) => {
     const aUnlocked = unlockedAchievements.includes(a.id);
     const bUnlocked = unlockedAchievements.includes(b.id);
@@ -24,13 +25,16 @@ const Achievements: React.FC<AchievementsProps> = ({ unlockedAchievements, allAc
             const isUnlocked = unlockedAchievements.includes(achievement.id);
             const badgeClasses = isUnlocked
               ? 'bg-white bg-opacity-40'
-              : 'bg-blue-900 bg-opacity-40 filter grayscale cursor-help';
+              : 'bg-blue-900 bg-opacity-40 filter grayscale cursor-pointer';
             const iconClass = isUnlocked ? 'text-amber-300' : 'text-gray-500';
             const textClass = isUnlocked ? 'text-indigo-800' : 'text-gray-300';
-            const description = isUnlocked ? achievement.description : 'Locked';
 
             return (
-              <div key={achievement.id} className={`achievement-badge ${badgeClasses} rounded-xl p-3 text-center transition-all duration-300 transform hover:scale-110`} title={`${achievement.name}: ${description}`}>
+              <div
+                key={achievement.id}
+                className={`achievement-badge ${badgeClasses} rounded-xl p-3 text-center transition-all duration-300 transform hover:scale-110`}
+                onClick={() => onAchievementClick(achievement, isUnlocked)}
+              >
                 <i className={`${achievement.icon} text-2xl mb-2 ${iconClass}`}></i>
                 <p className={`font-semibold text-xs ${textClass} break-words`}>{achievement.name}</p>
               </div>

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -12,11 +12,12 @@ interface StatsProps {
   dailyGoal: number;
   unlockedAchievements: string[];
   allAchievements: Achievement[];
+  onAchievementClick: (achievement: Achievement, isUnlocked: boolean) => void;
   exportData: () => void;
   importData: (file: File) => void;
 }
 
-const Stats: React.FC<StatsProps> = ({ logs, dailyGoal, unlockedAchievements, allAchievements, exportData, importData }) => {
+const Stats: React.FC<StatsProps> = ({ logs, dailyGoal, unlockedAchievements, allAchievements, onAchievementClick, exportData, importData }) => {
   return (
     <div className="space-y-8">
       <WeeklyChart logs={logs} dailyGoal={dailyGoal} />
@@ -24,6 +25,7 @@ const Stats: React.FC<StatsProps> = ({ logs, dailyGoal, unlockedAchievements, al
       <Achievements
         unlockedAchievements={unlockedAchievements}
         allAchievements={allAchievements}
+        onAchievementClick={onAchievementClick}
       />
       <Tips />
       <ExportData exportData={exportData} />


### PR DESCRIPTION
- Implements a popup modal that is triggered when a user clicks on an achievement.
- The modal displays different content based on the achievement's lock status.
- For unlocked achievements, it shows the icon, title, and description.
- For locked achievements, it shows a grayscale icon, the title, and a message indicating that the achievement is still locked.