### PR TITLE
fix(notifications): Use absolute URL for notification clicks

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -65,12 +65,13 @@ const scheduleNotifications = async () => {
 
       // Schedule the notification.
       const timerId = self.setTimeout(() => {
+        const notificationUrl = `${self.location.origin}/reminders?id=${reminder.id}`;
         self.registration.showNotification('AquaTracker Reminder', {
           body: reminder.title,
           icon: '/icons/icon-192-192.png',
           tag: reminder.id, // Use reminder ID as tag to prevent duplicate notifications.
           data: {
-            url: `/reminders?id=${reminder.id}`, // Pass URL to open on click.
+            url: notificationUrl, // Pass URL to open on click.
           },
         });
       }, timeDifference);


### PR DESCRIPTION
When a notification was clicked in production, it would lead to a 404 error. This was because the URL in the notification data was relative (e.g., `/reminders?id=123`), which did not work correctly when the app was not hosted at the root of the domain.

This change modifies the service worker (`src/sw.ts`) to construct an absolute URL by prepending `self.location.origin` to the relative path. This ensures that clicking a notification will always navigate to the correct page, regardless of the environment.