### PR TITLE
feat(notifications): use correct URL in production notifications

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -25,6 +25,8 @@ self.skipWaiting();
 // Their URLs are injected into the manifest variable below.
 precacheAndRoute(self.__WB_MANIFEST);
 
+declare const __APP_URL__: string;
+
 // --- Notification Logic ---
 
 // Instantiate the repository to access reminder data from IndexedDB.
@@ -53,7 +55,7 @@ const scheduleNotifications = async () => {
       const [hours, minutes] = reminder.time.split(':').map(Number);
 
       // Calculate the next occurrence of the reminder time.
-      let nextNotificationTime = new Date();
+      const nextNotificationTime = new Date();
       nextNotificationTime.setHours(hours, minutes, 0, 0);
 
       // If the time has already passed for today, schedule it for tomorrow.
@@ -70,7 +72,7 @@ const scheduleNotifications = async () => {
           icon: '/icons/icon-192-192.png',
           tag: reminder.id, // Use reminder ID as tag to prevent duplicate notifications.
           data: {
-            url: self.location.origin, // Pass URL to open on click.
+            url: __APP_URL__, // Pass URL to open on click.
           },
         });
       }, timeDifference);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,37 +9,45 @@ interface VitestConfigExport extends UserConfig {
   test: InlineConfig
 }
 
-export default defineConfig({
-  plugins: [
-    // The VitePWA plugin must be placed before other plugins to ensure it can
-    // correctly handle the service worker file in the development server.
-    VitePWA({
-      registerType: 'autoUpdate',
-      strategies: 'injectManifest',
-      srcDir: 'src',
-      filename: 'sw.ts',
-      includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'masked-icon.svg'],
-      devOptions: {
-        enabled: true,
-        type: 'module',
-      },
-      injectManifest: {},
-    }),
-    react(),
-    tailwindcss(),
-  ],
-  base: '/',
+export default defineConfig(({ mode }) => {
+  const productionUrl = 'https://aquatracker.schaflabs.com/';
+  const devUrl = 'http://localhost:5173';
+  const appUrl = mode === 'production' ? productionUrl : devUrl;
 
-  build: {
-    outDir: 'dist'
-  },
-  server: {
-    open: true,
-    port: 5173,
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    exclude: ['e2e/**', '**/node_modules/**'],
-  },
-} as VitestConfigExport)
+  return {
+    plugins: [
+      // The VitePWA plugin must be placed before other plugins to ensure it can
+      // correctly handle the service worker file in the development server.
+      VitePWA({
+        registerType: 'autoUpdate',
+        strategies: 'injectManifest',
+        srcDir: 'src',
+        filename: 'sw.ts',
+        includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'masked-icon.svg'],
+        devOptions: {
+          enabled: true,
+          type: 'module',
+        },
+        injectManifest: {},
+      }),
+      react(),
+      tailwindcss(),
+    ],
+    base: '/',
+    define: {
+      '__APP_URL__': JSON.stringify(appUrl),
+    },
+    build: {
+      outDir: 'dist',
+    },
+    server: {
+      open: true,
+      port: 5173,
+    },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      exclude: ['e2e/**', '**/node_modules/**'],
+    },
+  } as VitestConfigExport;
+})


### PR DESCRIPTION
This commit fixes a bug where clicking a notification in the production environment would lead to a 404 error. The issue was that the notification URL was created using `self.location.origin`, which is incorrect in the production build.

To fix this, I have introduced a build-time variable `__APP_URL__` that is injected by Vite. This variable holds the correct URL for the environment (`https://aquatracker.schaflabs.com/` for production, `http://localhost:5173` for development). The service worker now uses this variable to create the notification URL, ensuring that it is always correct.