### PR TITLE
Fix: Validate number input on blur

### DIFF
--- a/src/presentation/features/daily-tracker/DailyIntakeCard.tsx
+++ b/src/presentation/features/daily-tracker/DailyIntakeCard.tsx
@@ -17,8 +17,13 @@ interface DailyIntakeCardProps {
 
 const DailyIntakeCard: React.FC<DailyIntakeCardProps> = ({ dailyGoal, setDailyGoal, addWaterEntry, dailyTotal }) => {
   const [customAmount, setCustomAmount] = useState('');
+  const [goalInputValue, setGoalInputValue] = useState(dailyGoal.toString());
   const { getQuickAddValues } = useUseCases();
   const [quickAddValues, setQuickAddValues] = useState<QuickAddValues | null>(null);
+
+  useEffect(() => {
+    setGoalInputValue(dailyGoal.toString());
+  }, [dailyGoal]);
 
   const fetchQuickAddValues = useCallback(() => {
     getQuickAddValues.execute().then(setQuickAddValues);
@@ -91,11 +96,20 @@ const DailyIntakeCard: React.FC<DailyIntakeCardProps> = ({ dailyGoal, setDailyGo
               inputMode="numeric"
               pattern="[0-9]*"
               className="w-24 text-lg font-bold text-text-primary text-right bg-transparent focus:outline-none"
-              value={dailyGoal}
+              value={goalInputValue}
               onChange={(e) => {
                 const value = e.target.value;
                 if (/^\d*$/.test(value)) {
-                  setDailyGoal(parseInt(value, 10) || 0);
+                  setGoalInputValue(value);
+                }
+              }}
+              onBlur={() => {
+                const newGoal = parseInt(goalInputValue, 10);
+                if (!isNaN(newGoal)) {
+                  setDailyGoal(newGoal);
+                } else {
+                  // If input is invalid or empty, reset to the original goal
+                  setGoalInputValue(dailyGoal.toString());
                 }
               }}
               data-testid="goal-input"


### PR DESCRIPTION
- Implements on-blur validation for the daily goal input to prevent focus loss while typing.
- Introduces local state to manage the input value during editing.
- Reverts to the last valid goal if the input is invalid on blur.
- The core validation logic remains, ensuring values are between 100 and 9999.