### PR TITLE
Fix: Revert invalid goal input on blur

### DIFF
--- a/src/presentation/features/daily-tracker/DailyIntakeCard.tsx
+++ b/src/presentation/features/daily-tracker/DailyIntakeCard.tsx
@@ -10,7 +10,7 @@ import { showWarning } from '../../services/toast.service';
 
 interface DailyIntakeCardProps {
   dailyGoal: number;
-  setDailyGoal: (goal: number) => void;
+  setDailyGoal: (goal: number) => Promise<boolean>;
   addWaterEntry: (amount: number) => void;
   dailyTotal: number;
 }
@@ -42,11 +42,15 @@ const DailyIntakeCard: React.FC<DailyIntakeCardProps> = ({ dailyGoal, setDailyGo
   const intakeStatus = checkWaterIntake(dailyTotal).status;
   const isCritical = intakeStatus === INTAKE_STATUS.CRITICAL;
 
-  const handleGoalValidation = () => {
+  const handleGoalValidation = async () => {
     const newGoal = parseInt(goalInputValue, 10);
-    if (!isNaN(newGoal)) {
-      setDailyGoal(newGoal);
-    } else {
+    if (isNaN(newGoal)) {
+      setGoalInputValue(dailyGoal.toString());
+      return;
+    }
+
+    const success = await setDailyGoal(newGoal);
+    if (!success) {
       setGoalInputValue(dailyGoal.toString());
     }
   };

--- a/src/presentation/hooks/useDailyTracker.ts
+++ b/src/presentation/hooks/useDailyTracker.ts
@@ -75,22 +75,23 @@ export const useDailyTracker = () => {
     eventBus.emit('intakeDataChanged', undefined);
   }, [updateWaterIntake, recalculateAchievements]);
 
-  const handleSetGoal = useCallback(async (newGoal: number) => {
+  const handleSetGoal = useCallback(async (newGoal: number): Promise<boolean> => {
     if (isNaN(newGoal)) {
       showWarning('Please enter a valid number.');
-      return;
+      return false;
     }
     if (newGoal < 100) {
       showWarning('Goal cannot be less than 100.');
-      return;
+      return false;
     }
     if (newGoal > 9999) {
       showWarning('Goal cannot be greater than 9999.');
-      return;
+      return false;
     }
     await setDailyGoal.execute(newGoal);
     setGoal(newGoal);
     eventBus.emit('intakeDataChanged', undefined);
+    return true;
   }, [setDailyGoal]);
 
   return {


### PR DESCRIPTION
- Refactors the `setDailyGoal` function to return a boolean indicating validation success.
- Updates the `DailyIntakeCard` to check the validation result.
- If validation fails, the input field's value is reverted to the last valid goal.
- This ensures the UI remains consistent and the user always sees a valid state.