### PR TITLE
Fix: Align import and export card styling

### DIFF
--- a/src/presentation/features/settings/ExportData.tsx
+++ b/src/presentation/features/settings/ExportData.tsx
@@ -9,8 +9,8 @@ interface ExportDataProps {
 const ExportData: React.FC<ExportDataProps> = ({ exportData }) => {
   return (
     <Card>
-      <div className="text-center">
-        <h2 className="text-2xl font-bold text-text-primary mb-4">Export Your Data</h2>
+      <div>
+        <h2 className="text-xl font-bold text-text-primary mb-4">Export Your Data</h2>
         <p className="text-text-secondary mb-6">Download your water intake history for backup or analysis</p>
         <Button onClick={exportData}>
           <i className="fas fa-file-export mr-2"></i>Export as JSON

--- a/src/presentation/features/settings/ImportData.tsx
+++ b/src/presentation/features/settings/ImportData.tsx
@@ -24,10 +24,10 @@ const ImportData: React.FC<ImportDataProps> = ({ importData }) => {
 
   return (
     <Card>
-      <div className="text-center">
-        <h2 className="text-2xl font-bold text-text-primary mb-4">Import Your Data</h2>
+      <div>
+        <h2 className="text-xl font-bold text-text-primary mb-4">Import Your Data</h2>
         <p className="text-text-secondary mb-6">Import a previously exported JSON file to restore your data.</p>
-        <div className="flex flex-col items-center space-y-4">
+        <div className="flex flex-col items-start space-y-4">
           <input
             type="file"
             accept=".json"


### PR DESCRIPTION
The import and export cards had a larger title font size (text-2xl) and centered content, which was inconsistent with other cards in the application.

This change reduces the title font size to text-xl and removes the text-center alignment to match the styling of other cards, such as the General Settings card.